### PR TITLE
fix #46 Speech Recognition not working on Android Studio Emulator

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.justai.aimybox.assistant">
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+
     <application
         android:name=".AimyboxApplication"
         android:allowBackup="true"


### PR DESCRIPTION
needs RECORD_AUDIO permission for google.SpeechRecognizer working

this https://stackoverflow.com/questions/35248075/android-speech-recognition-insufficient-permission-error-code-9